### PR TITLE
Rust/leap add sample description

### DIFF
--- a/tracks/rust/.gitignore
+++ b/tracks/rust/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/tracks/rust/exercises/leap/Cargo.toml
+++ b/tracks/rust/exercises/leap/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "leap"
+version = "0.1.0"
+authors = ["Peter Tillemans <pti@melexis.com>"]
+
+[dependencies]

--- a/tracks/rust/exercises/leap/README.md
+++ b/tracks/rust/exercises/leap/README.md
@@ -59,5 +59,5 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
 ```
 
 This clearly shows that:
-- binding sub expressions is zero-cost
+- binding sub expressions is zero-cost as long as they have no side effects.
 - order of evaluation *does* matter

--- a/tracks/rust/exercises/leap/README.md
+++ b/tracks/rust/exercises/leap/README.md
@@ -1,0 +1,63 @@
+### Reasonable solutions
+
+```rust
+pub fn is_leap_year(year):
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+```
+
+### Common suggestions
+- there are just two cases that return True:
+  - a year is a multiple of 4 *and not** 100
+  - a year is a multiple of 4, 100, and 400
+- order of operations matter:
+  - 75% of all years *cannot* be leap years because they are not mulitples of 4;
+    test `year % 4 == 0` first
+  - 98.97% of all years that are multiples of 4 are not multiples of 100; test
+    `year % 100 != 0` second
+  - 1.03% of all years that are multiples of 4 are also multiples of 100 and
+    400; test `year % 400 == 0` third
+- order of evaluation matters:
+
+  ```rust
+  year $ 4 == 0 && year % 100 != 0 || year % 400 == 0
+  ```
+
+  _looks_ right, but will force a year like 999 to be checked for being a
+  multiple of 400 unnecessarily
+- eliminate duplicate work; no year should ever have to be checked multiple
+  times for the same condition
+
+### Talking points
+- it's very helpful to internalize the rules Rust uses for [expression
+  order](https://doc.rust-lang.org/reference/expressions.html#expression-precedence)
+- there is no compile time penalty of binding parts of the boolean expression to
+  a meaningful name and combine the afterwards
+
+### Benchmark code
+
+Included is a simple project which benchmarks some variants.
+
+- leap1 uses bindings to name subexpressions and combines them afterwards
+- leap2 uses the recommended expression above
+- leap3 uses an alternative expression
+- leap4 uses the counter example which shows that evaluation order matters
+
+results:
+
+```shell
+exercises/leap - [master●●] » cargo bench
+    Finished release [optimized] target(s) in 0.04s
+     Running target/release/deps/leap-ac2b7d8794582ded
+
+running 4 tests
+test tests::leap1_bench ... bench:       1,644 ns/iter (+/- 103)
+test tests::leap2_bench ... bench:       1,641 ns/iter (+/- 182)
+test tests::leap3_bench ... bench:       1,628 ns/iter (+/- 105)
+test tests::leap4_bench ... bench:       2,637 ns/iter (+/- 312)
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
+```
+
+This clearly shows that:
+- binding sub expressions is zero-cost
+- order of evaluation *does* matter

--- a/tracks/rust/exercises/leap/src/lib.rs
+++ b/tracks/rust/exercises/leap/src/lib.rs
@@ -1,0 +1,56 @@
+#![feature(test)]
+extern crate test;
+
+pub fn is_leap_year1(year: i32) -> bool {
+    let div_4 = year % 4 == 0;
+    let div_100 = year % 100 == 0;
+    let div_400 = year % 400 == 0;
+    div_4 && !(div_100 && !div_400)
+}
+
+pub fn is_leap_year2(year: i32) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+}
+
+pub fn is_leap_year3(year: i32) -> bool {
+    year % 4 == 0 && !(year % 100 == 0 && year % 400 != 0)
+}
+
+pub fn is_leap_year4(year: i32) -> bool {
+    year % 4 == 0 && year % 100 != 0 || year % 400 == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test::Bencher;
+
+    #[bench]
+    fn leap1_bench(b: &mut Bencher) {
+        b.iter( || {
+            (0..1200).fold(0, |cnt, year| if is_leap_year1(year) {cnt + 1} else {cnt})
+        })
+    }
+
+    #[bench]
+    fn leap2_bench(b: &mut Bencher) {
+        b.iter( || {
+            (0..1200).fold(0, |cnt, year| if is_leap_year2(year) {cnt + 1} else {cnt})
+        })
+    }
+
+    #[bench]
+    fn leap3_bench(b: &mut Bencher) {
+        b.iter( || {
+            (0..1200).fold(0, |cnt, year| if is_leap_year3(year) {cnt + 1} else {cnt})
+        })
+    }
+
+    #[bench]
+    fn leap4_bench(b: &mut Bencher) {
+        b.iter( || {
+            (0..1200).fold(0, |cnt, year| if is_leap_year4(year) {cnt + 1} else {cnt})
+        })
+    }
+
+}


### PR DESCRIPTION
I added some sample description for the *leap* exercise in the rust track. It is a non core exercise but I wanted to reuse @yawpitch work for python and also experiment and discuss on slack before starting the *real* work.

- I added a .gitignore on the rust track for avoiding stuff to be appearing in the repo.
- I converted the *README.md* from pythonese to rustish
- I added sample code with benchmarks to back up the claims in the READMP